### PR TITLE
feat: client methods to delete and list crds

### DIFF
--- a/client/tests/v2/tests.go
+++ b/client/tests/v2/tests.go
@@ -108,3 +108,18 @@ func (s TestsClient) DeleteAll() error {
 	err := s.Client.DeleteAllOf(context.Background(), u, client.InNamespace(s.Namespace))
 	return err
 }
+
+// DeleteByLabels deletes tests by labels
+func (s TestsClient) DeleteByLabels(selector string) error {
+	reqs, err := labels.ParseToRequirements(selector)
+	if err != nil {
+		return err
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetKind("Test")
+	u.SetAPIVersion("tests.testkube.io/v2")
+	err = s.Client.DeleteAllOf(context.Background(), u, client.InNamespace(s.Namespace),
+		client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(reqs...)})
+	return err
+}

--- a/client/testsuites/v1/testsuites.go
+++ b/client/testsuites/v1/testsuites.go
@@ -109,3 +109,18 @@ func (s TestSuitesClient) DeleteAll() error {
 	err := s.Client.DeleteAllOf(context.Background(), u, client.InNamespace(s.Namespace))
 	return err
 }
+
+// DeleteByLabels deletes TestSuites by labels
+func (s TestSuitesClient) DeleteByLabels(selector string) error {
+	reqs, err := labels.ParseToRequirements(selector)
+	if err != nil {
+		return err
+	}
+
+	u := &unstructured.Unstructured{}
+	u.SetKind("TestSuite")
+	u.SetAPIVersion("tests.testkube.io/v1")
+	err = s.Client.DeleteAllOf(context.Background(), u, client.InNamespace(s.Namespace),
+		client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(reqs...)})
+	return err
+}


### PR DESCRIPTION
Cclient methods to delete crds by labels as well as list webhook and executors

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-