### PR TITLE
feat: add command, image, imagePullSecrets to TestSpec and Executor for container executor

### DIFF
--- a/apis/executor/v1/executor_types.go
+++ b/apis/executor/v1/executor_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,7 +31,8 @@ type ExecutorSpec struct {
 	// Types defines what types can be handled by executor e.g. "postman/collection", ":curl/command" etc
 	Types []string `json:"types,omitempty"`
 
-	// ExecutorType one of "rest" for rest openapi based executors or "job" which will be default runners for testkube soon
+	// ExecutorType one of "rest" for rest openapi based executors or "job" which will be default runners for testkube
+	// or "container" for container executors
 	ExecutorType string `json:"executor_type,omitempty"`
 
 	// URI for rest based executors
@@ -38,6 +40,12 @@ type ExecutorSpec struct {
 
 	// Image for kube-job
 	Image string `json:"image,omitempty"`
+	// container executor binary arguments
+	Args []string `json:"args,omitempty"`
+	// container executor default binary command
+	Command []string `json:"command,omitempty"`
+	// container executor default image pull secrets
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// Features list of possible features which executor handles
 	Features []Feature `json:"features,omitempty"`

--- a/apis/executor/v1/zz_generated.deepcopy.go
+++ b/apis/executor/v1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -90,6 +91,21 @@ func (in *ExecutorSpec) DeepCopyInto(out *ExecutorSpec) {
 	if in.Types != nil {
 		in, out := &in.Types, &out.Types
 		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]corev1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
 	if in.Features != nil {

--- a/apis/tests/v3/test_types.go
+++ b/apis/tests/v3/test_types.go
@@ -18,6 +18,7 @@ package v3
 
 import (
 	commonv1 "github.com/kubeshop/testkube-operator/apis/common/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -101,6 +102,12 @@ type ExecutionRequest struct {
 	TestSuiteSecretUUID string `json:"testSuiteSecretUUID,omitempty"`
 	// additional executor binary arguments
 	Args []string `json:"args,omitempty"`
+	// container executor binary command
+	Command []string `json:"command,omitempty"`
+	// container executor image
+	Image string `json:"image,omitempty"`
+	// container executor image pull secrets
+	ImagePullSecrets []v1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	// environment variables passed to executor
 	Envs map[string]string `json:"envs,omitempty"`
 	// execution variables passed to executor from secrets

--- a/apis/tests/v3/zz_generated.deepcopy.go
+++ b/apis/tests/v3/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v3
 
 import (
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -45,6 +46,16 @@ func (in *ExecutionRequest) DeepCopyInto(out *ExecutionRequest) {
 	if in.Args != nil {
 		in, out := &in.Args, &out.Args
 		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
 	if in.Envs != nil {

--- a/config/crd/bases/executor.testkube.io_executors.yaml
+++ b/config/crd/bases/executor.testkube.io_executors.yaml
@@ -36,6 +36,16 @@ spec:
           spec:
             description: ExecutorSpec defines the desired state of Executor
             properties:
+              args:
+                description: container executor binary arguments
+                items:
+                  type: string
+                type: array
+              command:
+                description: container executor default binary command
+                items:
+                  type: string
+                type: array
               content_types:
                 description: ContentTypes list of handled content types
                 items:
@@ -48,7 +58,8 @@ spec:
                 type: array
               executor_type:
                 description: ExecutorType one of "rest" for rest openapi based executors
-                  or "job" which will be default runners for testkube soon
+                  or "job" which will be default runners for testkube or "container"
+                  for container executors
                 type: string
               features:
                 description: Features list of possible features which executor handles
@@ -61,6 +72,18 @@ spec:
               image:
                 description: Image for kube-job
                 type: string
+              imagePullSecrets:
+                description: container executor default image pull secrets
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                type: array
               job_template:
                 description: Job template to launch executor
                 type: string

--- a/config/crd/bases/tests.testkube.io_tests.yaml
+++ b/config/crd/bases/tests.testkube.io_tests.yaml
@@ -422,6 +422,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  command:
+                    description: container executor binary command
+                    items:
+                      type: string
+                    type: array
                   envs:
                     additionalProperties:
                       type: string
@@ -438,6 +443,21 @@ spec:
                   httpsProxy:
                     description: https proxy for executor containers
                     type: string
+                  image:
+                    description: container executor image
+                    type: string
+                  imagePullSecrets:
+                    description: container executor image pull secrets
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
                   name:
                     description: test execution custom name
                     type: string


### PR DESCRIPTION
## Pull request description 

Ref https://github.com/kubeshop/testkube/issues/2133

Example adding `image` and `command` to ExecutionRequest, example:
```
apiVersion: tests.testkube.io/v3
kind: Test
metadata:
  name: container-new
  namespace: testkube
spec:
  content:
    data: "123"
    type: string
  type: container/test
  executionRequest:
    command: ["curl"]
    image: curlimages/curl:7.85.0
    args:
    - -v
    - https://google.com
    envs:
      TESTKUBE_ENV: b
```

This similiar to Kubernetes:

```
    image: debian
    command: ["printenv"]
    args: ["HOSTNAME", "KUBERNETES_PORT"]
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-