### PR TITLE
fix: [TKC-1714] remove step sync

### DIFF
--- a/api/testsuite/v3/testsuite_types.go
+++ b/api/testsuite/v3/testsuite_types.go
@@ -207,8 +207,6 @@ type TestSuiteStepExecutionRequest struct {
 	ArgsMode ArgsModeType `json:"argsMode,omitempty"`
 	// executor binary command
 	Command []string `json:"command,omitempty"`
-	// whether to start execution sync or async
-	Sync bool `json:"sync,omitempty"`
 	// http proxy for executor containers
 	HttpProxy string `json:"httpProxy,omitempty"`
 	// https proxy for executor containers

--- a/config/crd/bases/tests.testkube.io_testsuites.yaml
+++ b/config/crd/bases/tests.testkube.io_testsuites.yaml
@@ -670,9 +670,6 @@ spec:
                               scraperTemplateReference:
                                 description: scraper template extensions reference
                                 type: string
-                              sync:
-                                description: whether to start execution sync or async
-                                type: boolean
                               variables:
                                 additionalProperties:
                                   properties:


### PR DESCRIPTION
## Pull request description 

To implement the order and parallelization of tests, users already have batch steps at their disposal, the `sync` flag in this context is therefore redundant.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-