### PR TITLE
fix: move "events" to top of the spec

### DIFF
--- a/api/testworkflows/v1/base_types.go
+++ b/api/testworkflows/v1/base_types.go
@@ -3,6 +3,9 @@ package v1
 type TestWorkflowSpecBase struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// events triggering execution of the test workflow
+	Events []Event `json:"events,omitempty" expr:"include"`
+
 	// make the instance configurable with some input data for scheduling it
 	Config map[string]ParameterSchema `json:"config,omitempty" expr:"include"`
 
@@ -17,7 +20,4 @@ type TestWorkflowSpecBase struct {
 
 	// configuration for the scheduled pod
 	Pod *PodConfig `json:"pod,omitempty" expr:"include"`
-
-	// events triggering execution of the test workflow
-	Events []Event `json:"events,omitempty" expr:"include"`
 }


### PR DESCRIPTION
## Pull request description 

* Move `events` to top of the spec, so they will be serialized on top

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test