### PR TITLE
fix yaml docs separator

### DIFF
--- a/config/crd/bases/tests.testkube.io_testtriggers.yaml
+++ b/config/crd/bases/tests.testkube.io_testtriggers.yaml
@@ -1,4 +1,4 @@
---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
## Pull request description 

YAML documents are separated by `---` instead of `--`. The current first line of that one file breaks parsing it with serde_yaml.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- None

## Changes

- None

## Fixes

- Fix YAML document separator