### PR TITLE
feat: [TKC-1948] disable webhooks

### DIFF
--- a/api/executor/v1/webhook_types.go
+++ b/api/executor/v1/webhook_types.go
@@ -42,6 +42,8 @@ type WebhookSpec struct {
 	PayloadTemplateReference string `json:"payloadTemplateReference,omitempty"`
 	// webhook headers (golang template supported)
 	Headers map[string]string `json:"headers,omitempty"`
+	// Disabled will disable the webhook
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=start-test;end-test-success;end-test-failed;end-test-aborted;end-test-timeout;start-testsuite;end-testsuite-success;end-testsuite-failed;end-testsuite-aborted;end-testsuite-timeout;start-testworkflow;queue-testworkflow;end-testworkflow-success;end-testworkflow-failed;end-testworkflow-aborted

--- a/config/crd/bases/executor.testkube.io_webhooks.yaml
+++ b/config/crd/bases/executor.testkube.io_webhooks.yaml
@@ -79,6 +79,9 @@ spec:
                 description: Uri is address where webhook should be made (golang template
                   supported)
                 type: string
+              disabled:
+                description: disable the webhook
+                type: boolean
             type: object
           status:
             description: WebhookStatus defines the observed state of Webhook


### PR DESCRIPTION
## Pull request description 

This PR adds a new field to the Webhook CRD called "Disabled". The purpose of this field is to mark a webhook inactive.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-