### PR TITLE
feat: add options to control Test Workflow' containers isolation

### DIFF
--- a/api/testworkflows/v1/base_types.go
+++ b/api/testworkflows/v1/base_types.go
@@ -31,8 +31,8 @@ type TestWorkflowSpecBase struct {
 
 type TestWorkflowSystem struct {
 	// assume all the steps are pure by default
-	PureByDefault bool `json:"pureByDefault,omitempty"`
+	PureByDefault *bool `json:"pureByDefault,omitempty"`
 
 	// disable the behavior of merging multiple operations in a single container
-	IsolatedContainers bool `json:"isolatedContainers,omitempty"`
+	IsolatedContainers *bool `json:"isolatedContainers,omitempty"`
 }

--- a/api/testworkflows/v1/base_types.go
+++ b/api/testworkflows/v1/base_types.go
@@ -6,6 +6,9 @@ type TestWorkflowSpecBase struct {
 	// events triggering execution of the test workflow
 	Events []Event `json:"events,omitempty" expr:"include"`
 
+	// system configuration to define the orchestration behavior
+	System *TestWorkflowSystem `json:"system,omitempty" expr:"include"`
+
 	// make the instance configurable with some input data for scheduling it
 	Config map[string]ParameterSchema `json:"config,omitempty" expr:"include"`
 
@@ -24,4 +27,12 @@ type TestWorkflowSpecBase struct {
 	// configuration for notifications
 	// Deprecated: field is not used
 	Notifications *NotificationsConfig `json:"notifications,omitempty" expr:"include"`
+}
+
+type TestWorkflowSystem struct {
+	// assume all the steps are pure by default
+	PureByDefault bool `json:"pureByDefault,omitempty"`
+
+	// disable the behavior of merging multiple operations in a single container
+	IsolatedContainers bool `json:"isolatedContainers,omitempty"`
 }

--- a/api/testworkflows/v1/step_types.go
+++ b/api/testworkflows/v1/step_types.go
@@ -24,6 +24,9 @@ type StepMeta struct {
 	// expression to declare under which conditions the step should be run
 	// defaults to: "passed", except artifacts where it defaults to "always"
 	Condition string `json:"condition,omitempty" expr:"expression"`
+
+	// mark the step as pure, applying optimizations to merge the containers together
+	Pure *bool `json:"pure,omitempty"`
 }
 
 type StepSource struct {

--- a/config/crd/bases/testworkflows.testkube.io_testworkflows.yaml
+++ b/config/crd/bases/testworkflows.testkube.io_testworkflows.yaml
@@ -1708,6 +1708,9 @@ spec:
                       paused:
                         description: pause the step initially
                         type: boolean
+                      pure:
+                        description: mark the step as pure, applying optimizations to merge the containers together
+                        type: boolean
                       retry:
                         description: policy for retrying the step
                         properties:
@@ -6434,6 +6437,9 @@ spec:
                       paused:
                         description: pause the step initially
                         type: boolean
+                      pure:
+                        description: mark the step as pure, applying optimizations to merge the containers together
+                        type: boolean
                       retry:
                         description: policy for retrying the step
                         properties:
@@ -9356,6 +9362,9 @@ spec:
                       paused:
                         description: pause the step initially
                         type: boolean
+                      pure:
+                        description: mark the step as pure, applying optimizations to merge the containers together
+                        type: boolean
                       retry:
                         description: policy for retrying the step
                         properties:
@@ -10612,6 +10621,16 @@ spec:
                         type: string
                     type: object
                   type: array
+                system:
+                  description: system configuration to define the orchestration behavior
+                  properties:
+                    isolatedContainers:
+                      description: disable the behavior of merging multiple operations in a single container
+                      type: boolean
+                    pureByDefault:
+                      description: assume all the steps are pure by default
+                      type: boolean
+                  type: object
                 use:
                   description: templates to include at a top-level of workflow
                   items:

--- a/config/crd/bases/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/config/crd/bases/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -1691,6 +1691,9 @@ spec:
                       paused:
                         description: pause the step initially
                         type: boolean
+                      pure:
+                        description: mark the step as pure, applying optimizations to merge the containers together
+                        type: boolean
                       retry:
                         description: policy for retrying the step
                         properties:
@@ -6323,6 +6326,9 @@ spec:
                       paused:
                         description: pause the step initially
                         type: boolean
+                      pure:
+                        description: mark the step as pure, applying optimizations to merge the containers together
+                        type: boolean
                       retry:
                         description: policy for retrying the step
                         properties:
@@ -9171,6 +9177,9 @@ spec:
                       paused:
                         description: pause the step initially
                         type: boolean
+                      pure:
+                        description: mark the step as pure, applying optimizations to merge the containers together
+                        type: boolean
                       retry:
                         description: policy for retrying the step
                         properties:
@@ -10370,6 +10379,16 @@ spec:
                         type: string
                     type: object
                   type: array
+                system:
+                  description: system configuration to define the orchestration behavior
+                  properties:
+                    isolatedContainers:
+                      description: disable the behavior of merging multiple operations in a single container
+                      type: boolean
+                    pureByDefault:
+                      description: assume all the steps are pure by default
+                      type: boolean
+                  type: object
               type: object
           required:
             - spec


### PR DESCRIPTION
## Pull request description 

* add `system.pureByDefault`
   * make everything pure by default; may be useful as a Global Template
* add `system.isolatedContainers`
   * to opt-out from the new mechanics of merging the operations within containers
* add `pure` on the step level
   * to allow configuring "purity" for specific steps

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-2372/workflows-istio-support-phase-2