### PR TITLE
feat: Add new Agent architecture detection for Execution controllers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/kelseyhightower/envconfig"
+
 	testtriggersv1 "github.com/kubeshop/testkube-operator/api/testtriggers/v1"
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 
@@ -333,19 +334,21 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&testexecutioncontrollers.TestExecutionReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ServiceName: httpConfig.Fullname,
-		ServicePort: httpConfig.Port,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		ServiceName:      httpConfig.Fullname,
+		ServicePort:      httpConfig.Port,
+		NamespaceChecker: cronJobManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TestExecution")
 		os.Exit(1)
 	}
 	if err = (&testsuiteexecutioncontrollers.TestSuiteExecutionReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ServiceName: httpConfig.Fullname,
-		ServicePort: httpConfig.Port,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		ServiceName:      httpConfig.Fullname,
+		ServicePort:      httpConfig.Port,
+		NamespaceChecker: cronJobManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TestSuiteExecution")
 		os.Exit(1)
@@ -378,10 +381,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&testworkflowexecutioncontrollers.TestWorkflowExecutionReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ServiceName: httpConfig.Fullname,
-		ServicePort: httpConfig.Port,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		ServiceName:      httpConfig.Fullname,
+		ServicePort:      httpConfig.Port,
+		NamespaceChecker: cronJobManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TestWorkflowExecution")
 		os.Exit(1)

--- a/internal/controller/testsuiteexecution/testsuiteexecution_controllller.go
+++ b/internal/controller/testsuiteexecution/testsuiteexecution_controllller.go
@@ -34,12 +34,17 @@ import (
 	testsuiteexecutionv1 "github.com/kubeshop/testkube-operator/api/testsuiteexecution/v1"
 )
 
+type NamespaceChecker interface {
+	IsNamespaceForNewArchitecture(namespace string) bool
+}
+
 // TestSuiteExecutionReconciler reconciles a TestSuiteExecution object
 type TestSuiteExecutionReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	ServiceName string
-	ServicePort int
+	Scheme           *runtime.Scheme
+	ServiceName      string
+	ServicePort      int
+	NamespaceChecker NamespaceChecker
 }
 
 //+kubebuilder:rbac:groups=tests.testkube.io,resources=testsuiteexecutions,verbs=get;list;watch;create;update;patch;delete
@@ -57,6 +62,10 @@ type TestSuiteExecutionReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *TestSuiteExecutionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
+
+	if r.NamespaceChecker.IsNamespaceForNewArchitecture(req.NamespacedName.Namespace) {
+		return ctrl.Result{}, nil
+	}
 
 	var testSuiteExecution testsuiteexecutionv1.TestSuiteExecution
 	err := r.Get(ctx, req.NamespacedName, &testSuiteExecution)

--- a/internal/controller/testworkflowexecution/testworkflowexecution_controller.go
+++ b/internal/controller/testworkflowexecution/testworkflowexecution_controller.go
@@ -34,12 +34,17 @@ import (
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 )
 
+type NamespaceChecker interface {
+	IsNamespaceForNewArchitecture(namespace string) bool
+}
+
 // TestWorkflowExecutionReconciler reconciles a TestWorkflowExecution object
 type TestWorkflowExecutionReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	ServiceName string
-	ServicePort int
+	Scheme           *runtime.Scheme
+	ServiceName      string
+	ServicePort      int
+	NamespaceChecker NamespaceChecker
 }
 
 //+kubebuilder:rbac:groups=testworkflows.testkube.io,resources=testworkflowexecutions,verbs=get;list;watch;create;update;patch;delete
@@ -57,6 +62,10 @@ type TestWorkflowExecutionReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.4/pkg/reconcile
 func (r *TestWorkflowExecutionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
+
+	if r.NamespaceChecker.IsNamespaceForNewArchitecture(req.NamespacedName.Namespace) {
+		return ctrl.Result{}, nil
+	}
 
 	var testWorkflowExecution testworkflowsv1.TestWorkflowExecution
 	err := r.Get(ctx, req.NamespacedName, &testWorkflowExecution)


### PR DESCRIPTION
## Pull request description 

Copies the existing new architecture detection mechanism used for `CronJobs` and `Tests`/`TestSuites` for `XxxExecution` resource controllers.

See https://github.com/kubeshop/testkube/pull/6386 for related Agent change

## Changes

- Prevent processing of `XxxExecution` resources in the namespaces that have an Agent which will process those resources instead..
