### PR TITLE
feat: resource and resourceSelector not required

### DIFF
--- a/api/testtriggers/v1/testtrigger_types.go
+++ b/api/testtriggers/v1/testtrigger_types.go
@@ -44,10 +44,13 @@ type TestTrigger struct {
 // TestTriggerSpec defines the desired state of TestTrigger
 type TestTriggerSpec struct {
 	// Selector is used to select events which trigger an action
+	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 	// For which Resource do we monitor Event which triggers an Action on certain conditions
+	// +optional
 	Resource TestTriggerResource `json:"resource"`
 	// ResourceSelector identifies which Kubernetes Objects should be watched
+	// +optional
 	ResourceSelector TestTriggerSelector `json:"resourceSelector"`
 	// On which Event for a Resource should an Action be triggered
 	Event TestTriggerEvent `json:"event"`

--- a/config/crd/bases/tests.testkube.io_testtriggers.yaml
+++ b/config/crd/bases/tests.testkube.io_testtriggers.yaml
@@ -430,8 +430,6 @@ spec:
             - action
             - event
             - execution
-            - resource
-            - resourceSelector
             - testSelector
             type: object
           status:


### PR DESCRIPTION
It should be possible to skip specifying them now and rely on new selector field solely.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-